### PR TITLE
Fix #1

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,12 +23,13 @@ Obsidian Magic Move is a Obsidian (https://obsidian.md) plugin for animating cod
 ## Usage
 
 - working in `Reading Mode`
-- use **\`\`\`\`magic-move** to wrap multiple code blocks
+- use **~~~magic-move** to wrap multiple code blocks
+- or **~~~markdown:magic-move** for syntax highlighting in editing mode
 - code block syntax is the same as you know
 - support code highlighting
 
-<pre>
-````magic-move
+````
+~~~markdown:magic-move
 ```vue
 import { defineComponent } from 'vue'
 
@@ -49,8 +50,8 @@ import { ref, computed } from 'vue'
 const count = ref(1)
 const double = computed(() => count.value * 2)
 ```
+~~~
 ````
-</pre>
 
 ## Settings
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -102,8 +102,10 @@ export default class MagicMovePlugin extends Plugin {
 	}
 
 	async readingMode(codeBlockElement: HTMLElement) {
+		const codeLangs = ['magic-move', 'markdown\\:magic-move']
+		const selectors = codeLangs.map((lang) => `pre > code.language-${lang}`)
 		const codeElm: HTMLElementExtend | null =
-			codeBlockElement.querySelector('pre > code.language-magic-move')
+			codeBlockElement.querySelector(selectors.join())
 
 		if (!codeElm) return
 

--- a/src/styles.css
+++ b/src/styles.css
@@ -78,7 +78,8 @@
 }
 
 /* hidden class */
-.language-magic-move {
+.language-magic-move,
+.language-markdown\:magic-move {
 	display: block !important;
 	padding: 0 !important;
 	min-height: 0 !important;


### PR DESCRIPTION
Applies Markdown syntax highlighting. Confirmed fixes #1 adding https://github.com/texastoland/obsidian-magic-move to [BRAT](https://obsidian.md/plugins?id=obsidian42-brat):

![CleanShot 2025-03-31 at 17 25 56@2x](https://github.com/user-attachments/assets/037d2443-a153-4e02-b688-9c61c767bc70)